### PR TITLE
Add Code of Conduct and update contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
+https://github.com/PyrotechSoftware/PyrotechUtilities/blob/dev/CONTRIBUTING.md
+
+Testing sections can be removed for documentation changes
+-->
+
+<!-- Provide a general summary of your changes in the Title above -->
+<!-- Keep the title short and descriptive, as it will be used as a commit message -->
+
+
+## Description
+<!-- Describe your changes in detail any why -->
+<!-- Note any issues that are resolved by this PR -->
+<!-- e.g. resolves #1337 or fixes #9310 -->
+
+## How Has This Been Tested?
+<!-- All PR's should implement unit tests if possible -->
+<!-- Please describe how you tested your changes. -->
+<!-- Have you created new tests or updated existing ones? -->
+<!-- e.g. unit | visually | none -->
+
+## Types of changes
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+<!-- If you made any visual changes, provide screenshots of before/after, it its moving parts, please provide high quality gif, wemb or mp4 -->
+
+## Checklist:
+<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] The PR is submitted to the correct branch (`dev`).
+- [ ] My code follows the code style of this project.
+- [ ] I've added relevant tests.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age,
+disability, ethnicity, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, etc.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team on Gitter. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# ![PyrotechUtilities](content/PyrotechUtilities-GitHub-NoBg.png)
+
+<!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
+
+- [Information and Guidelines for Contributors](#information-and-guidelines-for-contributors)
+   * [Code of Conduct](#code-of-conduct)
+   * [Minimal Prerequisites to Compile from Source](#minimal-prerequisites-to-compile-from-source)
+   * [Pull Requests](#pull-requests)
+      + [Pull Requests which introduce new components](#pull-requests-which-introduce-new-components)
+   * [Coding Dos and Don'ts](#coding-dos-and-donts)
+   * [Unit Testing and Continuous Integration](#unit-testing-and-continuous-integration)
+      + [How not to break stuff](#how-not-to-break-stuff)
+      + [Make your code break-safe](#make-your-code-break-safe)
+      + [How to write a unit test?](#how-to-write-a-unit-test)
+      + [What does not need to be tested?](#what-does-not-need-to-be-tested)
+      + [Continuous Integration](#continuous-integration)
+
+<!-- TOC end -->
+
+# Information and Guidelines for Contributors
+Thank you for contributing to PyrotechUtilities and making it even better. We are happy about every contribution! Issues, bug-fixes, new components...
+
+## Code of Conduct
+Please make sure that you follow our [code of conduct](/CODE_OF_CONDUCT.md)
+
+## Minimal Prerequisites to Compile from Source
+
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+
+## Pull Requests
+- Your Pull Request (PR) must only consist of one topic. It is better to split Pull Requests with more than one feature or bug fix in seperate Pull Requests
+- First fork the repository and clone your fork locally to make your changes. (The main repository is protected and does not accept direct commits.)
+- You should work on a seperate branch with a descriptive name. The following naming convention can be used: `feature/my-new-feature` for new features and enhancements, `fix/my-bug-fix` for bug fixes. For example `fix/button-hover-color` if your PR is about a bug involving the hover color of buttons
+- You should build, test and run one of the Docs projects locally to confirm your changes give the expected result. We generally suggest the PyrotechUtilities.Docs.Server project for the best debugging experience.
+- Choose `dev` as the target branch
+- All tests must pass, when you push, they will be executed on the CI server and you'll receive a test report per email. But you can also execute them locally for quicker feedback.
+- You must include tests when your Pull Requests alters any logic. This also ensures that your feature will not break in the future under changes from other contributors. For more information on testing, see the appropriate section below
+- If there are new changes in the main repo, you should either merge the main repo's (upstream) dev or rebase your branch onto it.
+- Before working on a large change, it is recommended to first open an issue to discuss it with others
+- If your Pull Request is still in progress, convert it to a draft Pull Request
+- The PR Title should follow the following format: 
+```
+<utility name>: <short description of changes in imperative> (<linked issue>)
+```
+For example:
+```
+ DateOnlyExtensions: Add Nullable Types (#1997)
+```
+- To keep your branch up to date with the `dev` branch simply merge `dev`. **Don't rebase** because if you rebase the wrong direction your PR will include tons of unrelated commits from dev.
+- Your Pull Request should not include any unnecessary refactoring
+- If there are visual changes, you should include a screenshot, gif or video
+- If there are any coresponding issues, link them to the Pull Request. Include `Fixes #<issue nr>` for bug fixes and `Closes #<issue nr>` for other issues in the description ([Link issues guide](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) 
+- Your code should be formatted correctly ([Format documentation](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/formatting-rules))
+
+
+## Coding Dos and Don'ts
+- **Don't break stuff!** See section *Unit Testing and Continuous Integration* below
+- **Add a test to guard against others breaking your feature/fix!** See section *Unit Testing and Continuous Integration* below
+
+## Unit Testing and Continuous Integration
+
+We strive for a complete test coverage in order to keep stuff from breaking and
+delivering a rock solid library. For every component that has C# logic we 
+require a bUnit test that is checking that logic.
+
+### How not to break stuff
+
+When you are making changes to any components and preparing a PR make
+sure you run the entire test suite to see if anything broke. 
+
+### Make your code break-safe
+
+When you are writing non-trivial logic, please add a unit test for it. Basically, think of it like this: By adding 
+a test for everything you fear could break you make sure your work is not undone by accident by future additions. 
+
+### How to write a unit test?
+
+It is actually dead simple. Look at some of the simpler tests like 
+- NumericExtensionsTests.cs for normal C# tests
+
+### Continuous Integration
+
+We have a Github Actions pipeline which will automatically execute the entire
+test suite on all pushes and PRs. So if your commit or PR breaks the tests
+you'll be notified.


### PR DESCRIPTION
- Introduced a Contributor Covenant Code of Conduct in `CODE_OF_CONDUCT.md`.
- Updated `CONTRIBUTING.md` to include a Code of Conduct section and a table of contents.
- Enhanced `PULL_REQUEST_TEMPLATE.md` to guide contributors on reading the contributing guide and structuring their PR descriptions.