### PR TITLE
Update version to 1.1.0 and add TimeOnly extensions

### DIFF
--- a/PyrotechUtilities.Tests/System/TimeOnlyExtensionsTests.cs
+++ b/PyrotechUtilities.Tests/System/TimeOnlyExtensionsTests.cs
@@ -1,0 +1,70 @@
+namespace PyrotechUtilities.Tests.System;
+
+#if NET6_0_OR_GREATER
+public class TimeOnlyExtensionsTests
+{
+    [Fact]
+    public void ToTimeOnly_FromTimeSpan_ReturnsExpectedTimeOnly()
+    {
+        var timeSpan = new TimeSpan(13, 45, 30);
+        var expected = new TimeOnly(13, 45, 30);
+
+        var result = timeSpan.ToTimeOnly();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToTimeOnly_FromNullableTimeSpan_ReturnsExpectedTimeOnly()
+    {
+        TimeSpan? timeSpan = new TimeSpan(8, 15, 0);
+        var expected = new TimeOnly(8, 15, 0);
+
+        var result = timeSpan.ToTimeOnly();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToTimeOnly_FromNullNullableTimeSpan_ReturnsNull()
+    {
+        TimeSpan? timeSpan = null;
+
+        var result = timeSpan.ToTimeOnly();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ToTimeSpan_FromTimeOnly_ReturnsExpectedTimeSpan()
+    {
+        var timeOnly = new TimeOnly(22, 10, 5);
+        var expected = new TimeSpan(22, 10, 5);
+
+        var result = timeOnly.ToTimeSpan();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToTimeSpan_FromNullableTimeOnly_ReturnsExpectedTimeSpan()
+    {
+        TimeOnly? timeOnly = new TimeOnly(6, 30, 0);
+        var expected = new TimeSpan(6, 30, 0);
+
+        var result = timeOnly.ToTimeSpan();
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToTimeSpan_FromNullNullableTimeOnly_ReturnsNull()
+    {
+        TimeOnly? timeOnly = null;
+
+        var result = timeOnly.ToTimeSpan();
+
+        Assert.Null(result);
+    }
+}
+#endif

--- a/PyrotechUtilities/PyrotechUtilities.csproj
+++ b/PyrotechUtilities/PyrotechUtilities.csproj
@@ -8,7 +8,7 @@
 
 	<PropertyGroup>
 		<PackageId>PyrotechUtilities</PackageId>
-		<VersionPrefix>1.0.0</VersionPrefix>
+		<VersionPrefix>1.1.0</VersionPrefix>
 		<VersionSuffix>$(VersionSuffix)</VersionSuffix>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageIcon>Nuget.png</PackageIcon>
@@ -16,7 +16,7 @@
 		<Authors>Bartthefish</Authors>
 		<Copyright>Copyright 2025 Pyrotech Software</Copyright>
 		<PackageTags>Pyrotech, Utilities, Extensions</PackageTags>
-		<Description>Various Extension methods for dealing with Enum, DateOnly and Numeric types</Description>
+		<Description>Various Extension methods for dealing with Enum, DateOnly, TimeOnly and Numeric types</Description>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/PyrotechUtilities/System/TimeOnlyExtensions.cs
+++ b/PyrotechUtilities/System/TimeOnlyExtensions.cs
@@ -1,0 +1,49 @@
+﻿#if NET6_0_OR_GREATER
+
+namespace System
+{
+    public static class TimeOnlyExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="TimeSpan"/> to a <see cref="TimeOnly"/>.
+        /// </summary>
+        /// <param name="timeSpan">The <see cref="TimeSpan"/> to convert.</param>
+        /// <returns>The converted <see cref="TimeOnly"/>.</returns>
+        public static TimeOnly ToTimeOnly(this TimeSpan timeSpan)
+        {
+            return new TimeOnly(timeSpan.Hours, timeSpan.Minutes, timeSpan.Seconds);
+        }
+
+        /// <summary>
+        /// Converts a nullable <see cref="TimeSpan"/> to a nullable <see cref="TimeOnly"/>.
+        /// </summary>
+        /// <param name="timeSpan">The nullable <see cref="TimeSpan"/> to convert.</param>
+        /// <returns>The converted nullable <see cref="TimeOnly"/>.</returns>
+        public static TimeOnly? ToTimeOnly(this TimeSpan? timeSpan)
+        {
+            return timeSpan.HasValue ? new TimeOnly(timeSpan.Value.Hours, timeSpan.Value.Minutes, timeSpan.Value.Seconds) : null;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="TimeOnly"/> to a <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <param name="timeOnly">The <see cref="TimeOnly"/> to convert.</param>
+        /// <returns>The converted <see cref="TimeSpan"/>.</returns>
+        public static TimeSpan ToTimeSpan(this TimeOnly timeOnly)
+        {
+            return new TimeSpan(timeOnly.Hour, timeOnly.Minute, timeOnly.Second);
+        }
+
+        /// <summary>
+        /// Converts a nullable <see cref="TimeOnly"/> to a nullable <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <param name="timeOnly">The nullable <see cref="TimeOnly"/> to convert.</param>
+        /// <returns>The converted nullable <see cref="TimeSpan"/>.</returns>
+        public static TimeSpan? ToTimeSpan(this TimeOnly? timeOnly)
+        {
+            return timeOnly.HasValue ? new TimeSpan(timeOnly.Value.Hour, timeOnly.Value.Minute, timeOnly.Value.Second) : null;
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Description
- Modified description to include TimeOnly in extension methods.
- Added new test cases in TimeOnlyExtensionsTests.cs for converting between TimeSpan and TimeOnly, including nullable handling.
- Introduced TimeOnlyExtensions class in TimeOnlyExtensions.cs with methods for converting TimeSpan to TimeOnly and vice versa, conditionally compiled for .NET 6.0 or greater.

## How Has This Been Tested?
unit

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.